### PR TITLE
Remove custom setters

### DIFF
--- a/src/main/java/com/todoist/pojo/Collaborator.kt
+++ b/src/main/java/com/todoist/pojo/Collaborator.kt
@@ -9,12 +9,9 @@ open class Collaborator @JvmOverloads constructor(
         projectsInvited: Collection<Long>? = null,
         isDeleted: Boolean = false
 ) : Person(id, email, fullName, imageId, isDeleted) {
-
     var projectsActive: Set<Long> = projectsActive.orEmpty().toSet()
-        private set
 
     var projectsInvited: Set<Long> = projectsInvited.orEmpty().toSet()
-        private set
 
     fun getProjectState(projectId: Long): String {
         return when {
@@ -43,24 +40,6 @@ open class Collaborator @JvmOverloads constructor(
 
             else -> throw IllegalArgumentException("Unknown state.")
         }
-    }
-
-    /**
-     * Copies the active project ids into an unmodifiable set.
-     *
-     * @see setProjectState
-     */
-    fun setProjectsActive(projectsActive: Collection<Long>) {
-        this.projectsActive = projectsActive.toSet()
-    }
-
-    /**
-     * Copies the invited project ids into an unmodifiable set.
-     *
-     * @see setProjectState
-     */
-    fun setProjectsInvited(projectsInvited: Collection<Long>) {
-        this.projectsInvited = projectsInvited.toSet()
     }
 
     companion object {

--- a/src/main/java/com/todoist/pojo/Collaborator.kt
+++ b/src/main/java/com/todoist/pojo/Collaborator.kt
@@ -5,20 +5,14 @@ open class Collaborator @JvmOverloads constructor(
         email: String,
         fullName: String = "",
         imageId: String? = null,
-        projectsActive: Collection<Long>? = null,
-        projectsInvited: Collection<Long>? = null,
+        open var projectsActive: Set<Long> = emptySet(),
+        open var projectsInvited: Set<Long> = emptySet(),
         isDeleted: Boolean = false
 ) : Person(id, email, fullName, imageId, isDeleted) {
-    var projectsActive: Set<Long> = projectsActive.orEmpty().toSet()
-
-    var projectsInvited: Set<Long> = projectsInvited.orEmpty().toSet()
-
-    fun getProjectState(projectId: Long): String {
-        return when {
-            projectsActive.contains(projectId) -> STATE_ACTIVE
-            projectsInvited.contains(projectId) -> STATE_INVITED
-            else -> STATE_DELETED
-        }
+    fun getProjectState(projectId: Long) = when {
+        projectsActive.contains(projectId) -> STATE_ACTIVE
+        projectsInvited.contains(projectId) -> STATE_INVITED
+        else -> STATE_DELETED
     }
 
     open fun setProjectState(projectId: Long, state: String) {

--- a/src/main/java/com/todoist/pojo/Item.kt
+++ b/src/main/java/com/todoist/pojo/Item.kt
@@ -20,10 +20,7 @@ open class Item<D : Due> @JvmOverloads constructor(
         open var dateCompleted: Long? = null,
         isDeleted: Boolean = false
 ) : TodoistObject(id, isDeleted) {
-    open var labels: Set<String> = labels?.toSet().orEmpty()
-        set(value) {
-            field = value.toSet()
-        }
+    open var labels: Set<String> = labels.orEmpty().toSet()
 
     /**
      * Returns the priority within the bounds defined by [.MIN_PRIORITY] and [.MAX_PRIORITY].
@@ -47,10 +44,6 @@ open class Item<D : Due> @JvmOverloads constructor(
                 dayOrder = -1
             }
         }
-
-    open fun setLabels(labels: Collection<String>?) {
-        this.labels = labels?.toSet().orEmpty()
-    }
 
     companion object {
         const val MIN_CHILD_ORDER = 1

--- a/src/main/java/com/todoist/pojo/Item.kt
+++ b/src/main/java/com/todoist/pojo/Item.kt
@@ -14,14 +14,12 @@ open class Item<D : Due> @JvmOverloads constructor(
         open var isCollapsed: Boolean = false,
         open var assignedByUid: Long?,
         open var responsibleUid: Long?,
-        labels: Collection<String>? = null,
+        open var labels: Set<String> = emptySet(),
         open var isInHistory: Boolean = false,
         open var dateAdded: Long,
         open var dateCompleted: Long? = null,
         isDeleted: Boolean = false
 ) : TodoistObject(id, isDeleted) {
-    open var labels: Set<String> = labels.orEmpty().toSet()
-
     /**
      * Returns the priority within the bounds defined by [.MIN_PRIORITY] and [.MAX_PRIORITY].
      */

--- a/src/main/java/com/todoist/pojo/Note.kt
+++ b/src/main/java/com/todoist/pojo/Note.kt
@@ -5,13 +5,11 @@ open class Note<F : FileAttachment> @JvmOverloads constructor(
         open var content: String?,
         open var posted: Long = System.currentTimeMillis(),
         open var postedUid: Long,
-        uidsToNotify: Collection<Long>?,
+        open var uidsToNotify: Set<Long> = emptySet(),
         open var fileAttachment: F? = null,
         open var reactions: Map<String, LongArray> = emptyMap(),
         open var projectId: Long?,
         open var itemId: Long?,
         open var isArchived: Boolean = false,
         isDeleted: Boolean = false
-) : TodoistObject(id, isDeleted) {
-    var uidsToNotify: Set<Long> = uidsToNotify.orEmpty().toSet()
-}
+) : TodoistObject(id, isDeleted)

--- a/src/main/java/com/todoist/pojo/Note.kt
+++ b/src/main/java/com/todoist/pojo/Note.kt
@@ -14,9 +14,4 @@ open class Note<F : FileAttachment> @JvmOverloads constructor(
         isDeleted: Boolean = false
 ) : TodoistObject(id, isDeleted) {
     var uidsToNotify: Set<Long> = uidsToNotify.orEmpty().toSet()
-        private set
-
-    fun setUidsToNotify(uidsToNotify: Collection<Long>) {
-        this.uidsToNotify = uidsToNotify.toSet()
-    }
 }


### PR DESCRIPTION
This PR removes some models legacy setters that used a generic collection and uses the property's setter (that expects a `Set` as a parameter).