### PR TITLE
Update `ViewOption` with new parameter `viewMode`

### DIFF
--- a/src/main/java/com/todoist/pojo/ViewOption.kt
+++ b/src/main/java/com/todoist/pojo/ViewOption.kt
@@ -8,6 +8,7 @@ open class ViewOption(
     open var sortOrder: SortOrder?,
     open var groupedBy: Group?,
     open var filteredBy: String?,
+    open var viewMode: ViewMode,
     isDeleted: Boolean
 ) : Model(id, isDeleted) {
     sealed class Type(protected open val key: String) {
@@ -75,6 +76,18 @@ open class ViewOption(
 
         companion object {
             fun get(groupKey: String?): Group? = values().find { it.key == groupKey }
+        }
+    }
+
+    enum class ViewMode(private val key: String) {
+        LIST("LIST"),
+        BOARD("BOARD");
+
+        override fun toString() = key
+
+        companion object {
+            fun get(viewKey: String?): ViewMode =
+                values().find { it.key == viewKey?.toUpperCase() } ?: LIST
         }
     }
 }


### PR DESCRIPTION
This parameter is used to determine if the view option for a selection
should be displayed in list or board view. [Twist ref](https://twist.com/a/1585/ch/405782/t/2225446/c/64962857)