### PR TITLE
Default child order

### DIFF
--- a/src/main/java/com/todoist/pojo/Item.kt
+++ b/src/main/java/com/todoist/pojo/Item.kt
@@ -11,7 +11,7 @@ open class Item<D : Due> @JvmOverloads constructor(
     open var sectionId: Long?,
     open var parentId: Long?,
     open var childOrder: Int = DEFAULT_CHILD_ORDER,
-    open var dayOrder: Int = DEF_DAY_ORDER,
+    open var dayOrder: Int = DEFAULT_DAY_ORDER,
     open var isChecked: Boolean = false,
     open var isCollapsed: Boolean = false,
     open var assignedByUid: Long?,
@@ -31,19 +31,19 @@ open class Item<D : Due> @JvmOverloads constructor(
         set(value) {
             if (field != value) {
                 field = value
-                dayOrder = DEF_DAY_ORDER
+                dayOrder = DEFAULT_DAY_ORDER
             }
         }
 
     /**
      * Sets the due date, with the side effect of resetting the day order to its default value of
-     * [DEF_DAY_ORDER].
+     * [DEFAULT_DAY_ORDER].
      */
     open var due: D? = due
         set(value) {
             if (field != value) {
                 field = value
-                dayOrder = DEF_DAY_ORDER
+                dayOrder = DEFAULT_DAY_ORDER
             }
         }
 
@@ -53,7 +53,7 @@ open class Item<D : Due> @JvmOverloads constructor(
         const val MAX_DEPTH = 4
         const val MIN_PRIORITY = 1
         const val MAX_PRIORITY = 4
-        const val DEF_DAY_ORDER = -1
+        const val DEFAULT_DAY_ORDER = -1
         const val MAX_LABEL_COUNT = 100
         const val MAX_CONTENT_CHAR_COUNT = 500
         const val MAX_DESCRIPTION_CHAR_COUNT = 16384

--- a/src/main/java/com/todoist/pojo/Item.kt
+++ b/src/main/java/com/todoist/pojo/Item.kt
@@ -10,7 +10,7 @@ open class Item<D : Due> @JvmOverloads constructor(
     due: D?,
     open var sectionId: Long?,
     open var parentId: Long?,
-    open var childOrder: Int = MIN_CHILD_ORDER,
+    open var childOrder: Int = DEFAULT_CHILD_ORDER,
     open var dayOrder: Int = DEF_DAY_ORDER,
     open var isChecked: Boolean = false,
     open var isCollapsed: Boolean = false,
@@ -48,7 +48,7 @@ open class Item<D : Due> @JvmOverloads constructor(
         }
 
     companion object {
-        const val MIN_CHILD_ORDER = 1
+        const val DEFAULT_CHILD_ORDER = 1
         const val MIN_DEPTH = 0
         const val MAX_DEPTH = 4
         const val MIN_PRIORITY = 1

--- a/src/main/java/com/todoist/pojo/Project.kt
+++ b/src/main/java/com/todoist/pojo/Project.kt
@@ -60,7 +60,7 @@ open class Project @JvmOverloads constructor(
         const val VIEW_STYLE_BOARD = "board"
         const val VIEW_STYLE_DEFAULT = VIEW_STYLE_LIST
 
-        const val MIN_CHILD_ORDER = 1
+        const val DEFAULT_CHILD_ORDER = 1
         const val MIN_DEPTH = 0
         const val MAX_DEPTH = 3
 

--- a/src/main/java/com/todoist/pojo/Section.kt
+++ b/src/main/java/com/todoist/pojo/Section.kt
@@ -13,7 +13,7 @@ open class Section @JvmOverloads constructor(
     isDeleted: Boolean = false
 ) : Model(id, isDeleted) {
     companion object {
-        const val MIN_CHILD_ORDER = 1
+        const val DEFAULT_CHILD_ORDER = 1
         const val MIN_DEPTH = 0
 
         @JvmStatic


### PR DESCRIPTION
This PR renames `MIN_CHILD_ORDER` to `DEFAULT_CHILD_ORDER`.

It's possible that `child_order` gets negative so the new name makes more sense.