### PR TITLE
Add multi-factor authentication status to User object

### DIFF
--- a/src/main/java/com/todoist/pojo/User.kt
+++ b/src/main/java/com/todoist/pojo/User.kt
@@ -30,6 +30,7 @@ open class User<T : TzInfo, F : Features>(
     open var uniquePrefix: Long?,
     open var hasPassword: Boolean,
     open var verificationStatus: VerificationStatus,
+    open var multiFactorAuthEnabled: Boolean,
 ) : Person(id, email, fullName, imageId, false) {
     enum class VerificationStatus(private val key: String) {
         VERIFIED("verified"),


### PR DESCRIPTION
As title says. Required to identify if a user has activated or deactivated multi-factor authentication on their account.

**API Spec (Optional)**
https://github.com/Doist/secdo-api-specs