### PR TITLE
Update avatar initials logic

### DIFF
--- a/src/main/java/com/todoist/pojo/Person.kt
+++ b/src/main/java/com/todoist/pojo/Person.kt
@@ -7,7 +7,7 @@ open class Person(
     open var imageId: String?,
     isDeleted: Boolean
 ) : Model(id, isDeleted) {
-    val defaultAvatarText get() = getDefaultAvatarText(fullName)
+    val defaultAvatarText get() = getDefaultAvatarText(fullName, email)
 
     fun getDefaultAvatarColorInt(useLightColors: Boolean) =
         getDefaultAvatarColorInt(email, useLightColors)
@@ -64,15 +64,31 @@ open class Person(
         }
 
         @JvmStatic
-        fun getDefaultAvatarText(fullName: String): String {
-            val escapedName = fullName.replace(ESCAPE_PATTERN, "").trim()
-            if (escapedName.isBlank()) return "?"
+        fun getDefaultAvatarText(fullName: String?, email: String?): String {
+            val escapedName = fullName?.replace(ESCAPE_PATTERN, "")?.trim().orEmpty()
+            if (escapedName.isBlank()) {
+                return getEmailInitials(email)
+            }
 
             val first = escapedName[0].uppercaseChar()
             val lastSpace = escapedName.indexOfLast { it.isWhitespace() }
             val last =
                 if (lastSpace != -1) escapedName[lastSpace + 1].uppercaseChar().toString() else ""
             return first + last
+        }
+
+        private fun getEmailInitials(email: String?): String {
+            val validEmail = email ?: "?"
+            return buildString {
+                val emailInitials = validEmail.substringBefore("@")
+                    .split(".")
+                    .filter { it.isNotEmpty() }
+                    .map { emailPart -> emailPart.first().uppercase() }
+                append(emailInitials.firstOrNull().orEmpty())
+                if (emailInitials.size > 1) {
+                    append(emailInitials.lastOrNull().orEmpty())
+                }
+            }
         }
     }
 }

--- a/src/test/java/com/todoist/pojo/PersonTest.kt
+++ b/src/test/java/com/todoist/pojo/PersonTest.kt
@@ -1,24 +1,24 @@
 package com.todoist.pojo
 
-import kotlin.test.assertEquals
 import kotlin.test.Test
+import kotlin.test.assertEquals
 
 class PersonTest {
     @Test
     fun getDefaultAvatarText() {
         listOf(
-            "First Last" to "FL",
-            "Not capitalized" to "NC",
-            " White\n\nSpace  " to "WS",
-            "ã ž" to "ÃŽ",
-            "Ludwig van Beethoven" to "LB",
-            "[Spe-cial], (Chars)" to "SC",
-            "\u00A0NO-BREAK\u00A0SPACE\u00A0" to "NS",
-            "Mononym" to "M",
-            "Q" to "Q",
-            "  " to "?"
-        ).forEach { (fullName, defaultAvatarText) ->
-            assertEquals(defaultAvatarText, Person.getDefaultAvatarText(fullName))
+            Triple("First Last", "test@doist.com", "FL"),
+            Triple("Not capitalized", "test@doist.com", "NC"),
+            Triple(" White\n\nSpace  ", "test@doist.com", "WS"),
+            Triple("ã ž", "test@doist.com", "ÃŽ"),
+            Triple("Ludwig van Beethoven", "test@doist.com", "LB"),
+            Triple("[Spe-cial], (Chars)", "test@doist.com", "SC"),
+            Triple("\u00A0NO-BREAK\u00A0SPACE\u00A0", "test@doist.com", "NS"),
+            Triple("Mononym", "test@doist.com", "M"),
+            Triple("Q", "test@doist.com", "Q"),
+            Triple("  ", "test@doist.com", "T"),
+        ).forEach { (fullName, email, defaultAvatarText) ->
+            assertEquals(defaultAvatarText, Person.getDefaultAvatarText(fullName, email))
         }
     }
 }


### PR DESCRIPTION
The avatar with initials is now required during onboarding. Although, the user's name, which forms the initials might not be available at some point, the email is used in such situation.

Related to https://github.com/Doist/Todoist-Android/pull/3417